### PR TITLE
Compatibility with poetry >= 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,5 +18,5 @@ flake8 = "^6.0.0"
 mypy = "^1.1.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
New versions of poetry don't support the "poetry.masonry.api" import path.